### PR TITLE
feat: add --custom-only flag to skills generate

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -47,6 +47,13 @@ var knownKeys = []configKey{
 		Get:         func(s *auth.Settings) string { return s.SkillsExclude },
 		Set:         func(s *auth.Settings, v string) { s.SkillsExclude = v },
 	},
+	{
+		CLI:         "skills.custom_only",
+		Description: "Only generate custom skills, skip MCP tools (true/false)",
+		Default:     "",
+		Get:         func(s *auth.Settings) string { return s.SkillsCustomOnly },
+		Set:         func(s *auth.Settings, v string) { s.SkillsCustomOnly = v },
+	},
 }
 
 func findKey(name string) *configKey {
@@ -81,6 +88,10 @@ func validateConfigValue(key, value string) error {
 			if _, err := regexp.Compile(value); err != nil {
 				return fmt.Errorf("invalid regex for %s: %w", key, err)
 			}
+		}
+	case "skills.custom_only":
+		if value != "" && value != "true" && value != "false" {
+			return fmt.Errorf("invalid value %q for %q: must be \"true\" or \"false\"", value, key)
 		}
 	}
 	return nil

--- a/cmd/skills.go
+++ b/cmd/skills.go
@@ -26,6 +26,7 @@ var skillsInstallHook bool
 var skillsPullLatest bool
 var skillsInclude string
 var skillsExclude string
+var skillsCustomOnly bool
 
 var skillsCmd = &cobra.Command{
 	Use:   "skills",
@@ -69,11 +70,11 @@ and regenerates them.`,
 			}
 			fmt.Fprintln(cmd.OutOrStdout(), "Server skills cache refreshed")
 		}
-		include, exclude, err := resolveSkillFilters(cmd)
+		include, exclude, customOnly, err := resolveSkillFilters(cmd)
 		if err != nil {
 			return err
 		}
-		outDir, err := skills.Generate(GetConfig(), skillsAgent, skillsPath, include, exclude, RoutingSkill)
+		outDir, err := skills.Generate(GetConfig(), skillsAgent, skillsPath, include, exclude, customOnly, RoutingSkill)
 		if err != nil {
 			return err
 		}
@@ -90,10 +91,10 @@ and regenerates them.`,
 
 // resolveSkillFilters applies the standard 4-tier precedence for skill filters:
 // flag > env > settings.json > default (empty).
-func resolveSkillFilters(cmd *cobra.Command) (include, exclude string, err error) {
+func resolveSkillFilters(cmd *cobra.Command) (include, exclude string, customOnly bool, err error) {
 	settings, err := auth.LoadSettings()
 	if err != nil {
-		return "", "", err
+		return "", "", false, err
 	}
 
 	if cmd.Flags().Changed("include") {
@@ -112,7 +113,15 @@ func resolveSkillFilters(cmd *cobra.Command) (include, exclude string, err error
 		exclude = settings.SkillsExclude
 	}
 
-	return include, exclude, nil
+	if cmd.Flags().Changed("custom-only") {
+		customOnly = skillsCustomOnly
+	} else if v, ok := os.LookupEnv("DOT_AI_SKILLS_CUSTOM_ONLY"); ok {
+		customOnly = v == "true" || v == "1" || v == "yes"
+	} else {
+		customOnly = settings.SkillsCustomOnly == "true"
+	}
+
+	return include, exclude, customOnly, nil
 }
 
 func init() {
@@ -122,6 +131,7 @@ func init() {
 	skillsGenerateCmd.Flags().BoolVar(&skillsPullLatest, "pull-latest", false, "Force the server to pull the latest skills from the git repository before generating")
 	skillsGenerateCmd.Flags().StringVar(&skillsInclude, "include", "", "Regex to filter skills to include (env: DOT_AI_SKILLS_INCLUDE)")
 	skillsGenerateCmd.Flags().StringVar(&skillsExclude, "exclude", "", "Regex to filter skills to exclude (env: DOT_AI_SKILLS_EXCLUDE)")
+	skillsGenerateCmd.Flags().BoolVar(&skillsCustomOnly, "custom-only", false, "Only generate custom prompt skills, skip MCP tool skills (env: DOT_AI_SKILLS_CUSTOM_ONLY)")
 	skillsGenerateCmd.RegisterFlagCompletionFunc("agent", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return agentNames(), cobra.ShellCompDirectiveNoFileComp
 	})

--- a/cmd/skills.go
+++ b/cmd/skills.go
@@ -116,7 +116,7 @@ func resolveSkillFilters(cmd *cobra.Command) (include, exclude string, customOnl
 	if cmd.Flags().Changed("custom-only") {
 		customOnly = skillsCustomOnly
 	} else if v, ok := os.LookupEnv("DOT_AI_SKILLS_CUSTOM_ONLY"); ok {
-		customOnly = v == "true" || v == "1" || v == "yes"
+		customOnly = v == "true"
 	} else {
 		customOnly = settings.SkillsCustomOnly == "true"
 	}

--- a/e2e/config_test.go
+++ b/e2e/config_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestConfigSet_SetsValue(t *testing.T) {
 	home := t.TempDir()
-	env := []string{"HOME=" + home, "XDG_CONFIG_HOME=", "DOT_AI_URL=", "DOT_AI_OUTPUT_FORMAT=", "DOT_AI_SKILLS_INCLUDE=", "DOT_AI_SKILLS_EXCLUDE=", "DOT_AI_AUTH_TOKEN="}
+	env := []string{"HOME=" + home, "XDG_CONFIG_HOME=", "DOT_AI_URL=", "DOT_AI_OUTPUT_FORMAT=", "DOT_AI_SKILLS_INCLUDE=", "DOT_AI_SKILLS_EXCLUDE=", "DOT_AI_SKILLS_CUSTOM_ONLY=", "DOT_AI_AUTH_TOKEN="}
 
 	// Set a value.
 	stdout, stderr, exitCode := runCLIWithEnv(t, env, "config", "set", "server-url", "https://example.com")
@@ -35,7 +35,7 @@ func TestConfigSet_SetsValue(t *testing.T) {
 
 func TestConfigGet_ReturnsDefault(t *testing.T) {
 	home := t.TempDir()
-	env := []string{"HOME=" + home, "XDG_CONFIG_HOME=", "DOT_AI_URL=", "DOT_AI_OUTPUT_FORMAT=", "DOT_AI_SKILLS_INCLUDE=", "DOT_AI_SKILLS_EXCLUDE=", "DOT_AI_AUTH_TOKEN="}
+	env := []string{"HOME=" + home, "XDG_CONFIG_HOME=", "DOT_AI_URL=", "DOT_AI_OUTPUT_FORMAT=", "DOT_AI_SKILLS_INCLUDE=", "DOT_AI_SKILLS_EXCLUDE=", "DOT_AI_SKILLS_CUSTOM_ONLY=", "DOT_AI_AUTH_TOKEN="}
 
 	stdout, stderr, exitCode := runCLIWithEnv(t, env, "config", "get", "output-format")
 	if exitCode != 0 {
@@ -48,7 +48,7 @@ func TestConfigGet_ReturnsDefault(t *testing.T) {
 
 func TestConfigGet_ReturnsNotSet(t *testing.T) {
 	home := t.TempDir()
-	env := []string{"HOME=" + home, "XDG_CONFIG_HOME=", "DOT_AI_URL=", "DOT_AI_OUTPUT_FORMAT=", "DOT_AI_SKILLS_INCLUDE=", "DOT_AI_SKILLS_EXCLUDE=", "DOT_AI_AUTH_TOKEN="}
+	env := []string{"HOME=" + home, "XDG_CONFIG_HOME=", "DOT_AI_URL=", "DOT_AI_OUTPUT_FORMAT=", "DOT_AI_SKILLS_INCLUDE=", "DOT_AI_SKILLS_EXCLUDE=", "DOT_AI_SKILLS_CUSTOM_ONLY=", "DOT_AI_AUTH_TOKEN="}
 
 	stdout, stderr, exitCode := runCLIWithEnv(t, env, "config", "get", "skills.include")
 	if exitCode != 0 {
@@ -61,13 +61,13 @@ func TestConfigGet_ReturnsNotSet(t *testing.T) {
 
 func TestConfigList_ShowsAllKeys(t *testing.T) {
 	home := t.TempDir()
-	env := []string{"HOME=" + home, "XDG_CONFIG_HOME=", "DOT_AI_URL=", "DOT_AI_OUTPUT_FORMAT=", "DOT_AI_SKILLS_INCLUDE=", "DOT_AI_SKILLS_EXCLUDE=", "DOT_AI_AUTH_TOKEN="}
+	env := []string{"HOME=" + home, "XDG_CONFIG_HOME=", "DOT_AI_URL=", "DOT_AI_OUTPUT_FORMAT=", "DOT_AI_SKILLS_INCLUDE=", "DOT_AI_SKILLS_EXCLUDE=", "DOT_AI_SKILLS_CUSTOM_ONLY=", "DOT_AI_AUTH_TOKEN="}
 
 	stdout, stderr, exitCode := runCLIWithEnv(t, env, "config", "list")
 	if exitCode != 0 {
 		t.Fatalf("exit %d; stderr: %s", exitCode, stderr)
 	}
-	for _, key := range []string{"server-url", "output-format", "skills.include", "skills.exclude"} {
+	for _, key := range []string{"server-url", "output-format", "skills.include", "skills.exclude", "skills.custom_only"} {
 		if !strings.Contains(stdout, key) {
 			t.Errorf("list output missing key %q; got: %s", key, stdout)
 		}
@@ -76,7 +76,7 @@ func TestConfigList_ShowsAllKeys(t *testing.T) {
 
 func TestConfigList_ShowsSetAndDefaultValues(t *testing.T) {
 	home := t.TempDir()
-	env := []string{"HOME=" + home, "XDG_CONFIG_HOME=", "DOT_AI_URL=", "DOT_AI_OUTPUT_FORMAT=", "DOT_AI_SKILLS_INCLUDE=", "DOT_AI_SKILLS_EXCLUDE=", "DOT_AI_AUTH_TOKEN="}
+	env := []string{"HOME=" + home, "XDG_CONFIG_HOME=", "DOT_AI_URL=", "DOT_AI_OUTPUT_FORMAT=", "DOT_AI_SKILLS_INCLUDE=", "DOT_AI_SKILLS_EXCLUDE=", "DOT_AI_SKILLS_CUSTOM_ONLY=", "DOT_AI_AUTH_TOKEN="}
 
 	// Set one key.
 	_, _, exitCode := runCLIWithEnv(t, env, "config", "set", "server-url", "https://custom.example.com")
@@ -98,7 +98,7 @@ func TestConfigList_ShowsSetAndDefaultValues(t *testing.T) {
 
 func TestConfigReset_ClearsValue(t *testing.T) {
 	home := t.TempDir()
-	env := []string{"HOME=" + home, "XDG_CONFIG_HOME=", "DOT_AI_URL=", "DOT_AI_OUTPUT_FORMAT=", "DOT_AI_SKILLS_INCLUDE=", "DOT_AI_SKILLS_EXCLUDE=", "DOT_AI_AUTH_TOKEN="}
+	env := []string{"HOME=" + home, "XDG_CONFIG_HOME=", "DOT_AI_URL=", "DOT_AI_OUTPUT_FORMAT=", "DOT_AI_SKILLS_INCLUDE=", "DOT_AI_SKILLS_EXCLUDE=", "DOT_AI_SKILLS_CUSTOM_ONLY=", "DOT_AI_AUTH_TOKEN="}
 
 	// Set then reset.
 	_, setStderr, setExit := runCLIWithEnv(t, env, "config", "set", "server-url", "https://example.com")
@@ -125,7 +125,7 @@ func TestConfigReset_ClearsValue(t *testing.T) {
 
 func TestConfigReset_WithDefault(t *testing.T) {
 	home := t.TempDir()
-	env := []string{"HOME=" + home, "XDG_CONFIG_HOME=", "DOT_AI_URL=", "DOT_AI_OUTPUT_FORMAT=", "DOT_AI_SKILLS_INCLUDE=", "DOT_AI_SKILLS_EXCLUDE=", "DOT_AI_AUTH_TOKEN="}
+	env := []string{"HOME=" + home, "XDG_CONFIG_HOME=", "DOT_AI_URL=", "DOT_AI_OUTPUT_FORMAT=", "DOT_AI_SKILLS_INCLUDE=", "DOT_AI_SKILLS_EXCLUDE=", "DOT_AI_SKILLS_CUSTOM_ONLY=", "DOT_AI_AUTH_TOKEN="}
 
 	_, setStderr, setExit := runCLIWithEnv(t, env, "config", "set", "output-format", "json")
 	if setExit != 0 {
@@ -147,7 +147,7 @@ func TestConfigReset_WithDefault(t *testing.T) {
 
 func TestConfigSet_UnknownKey_Error(t *testing.T) {
 	home := t.TempDir()
-	env := []string{"HOME=" + home, "XDG_CONFIG_HOME=", "DOT_AI_URL=", "DOT_AI_OUTPUT_FORMAT=", "DOT_AI_SKILLS_INCLUDE=", "DOT_AI_SKILLS_EXCLUDE=", "DOT_AI_AUTH_TOKEN="}
+	env := []string{"HOME=" + home, "XDG_CONFIG_HOME=", "DOT_AI_URL=", "DOT_AI_OUTPUT_FORMAT=", "DOT_AI_SKILLS_INCLUDE=", "DOT_AI_SKILLS_EXCLUDE=", "DOT_AI_SKILLS_CUSTOM_ONLY=", "DOT_AI_AUTH_TOKEN="}
 
 	_, stderr, exitCode := runCLIWithEnv(t, env, "config", "set", "foo", "bar")
 	if exitCode == 0 {
@@ -163,7 +163,7 @@ func TestConfigSet_UnknownKey_Error(t *testing.T) {
 
 func TestConfigGet_UnknownKey_Error(t *testing.T) {
 	home := t.TempDir()
-	env := []string{"HOME=" + home, "XDG_CONFIG_HOME=", "DOT_AI_URL=", "DOT_AI_OUTPUT_FORMAT=", "DOT_AI_SKILLS_INCLUDE=", "DOT_AI_SKILLS_EXCLUDE=", "DOT_AI_AUTH_TOKEN="}
+	env := []string{"HOME=" + home, "XDG_CONFIG_HOME=", "DOT_AI_URL=", "DOT_AI_OUTPUT_FORMAT=", "DOT_AI_SKILLS_INCLUDE=", "DOT_AI_SKILLS_EXCLUDE=", "DOT_AI_SKILLS_CUSTOM_ONLY=", "DOT_AI_AUTH_TOKEN="}
 
 	_, stderr, exitCode := runCLIWithEnv(t, env, "config", "get", "foo")
 	if exitCode == 0 {
@@ -176,7 +176,7 @@ func TestConfigGet_UnknownKey_Error(t *testing.T) {
 
 func TestConfigReset_UnknownKey_Error(t *testing.T) {
 	home := t.TempDir()
-	env := []string{"HOME=" + home, "XDG_CONFIG_HOME=", "DOT_AI_URL=", "DOT_AI_OUTPUT_FORMAT=", "DOT_AI_SKILLS_INCLUDE=", "DOT_AI_SKILLS_EXCLUDE=", "DOT_AI_AUTH_TOKEN="}
+	env := []string{"HOME=" + home, "XDG_CONFIG_HOME=", "DOT_AI_URL=", "DOT_AI_OUTPUT_FORMAT=", "DOT_AI_SKILLS_INCLUDE=", "DOT_AI_SKILLS_EXCLUDE=", "DOT_AI_SKILLS_CUSTOM_ONLY=", "DOT_AI_AUTH_TOKEN="}
 
 	_, stderr, exitCode := runCLIWithEnv(t, env, "config", "reset", "foo")
 	if exitCode == 0 {
@@ -189,7 +189,7 @@ func TestConfigReset_UnknownKey_Error(t *testing.T) {
 
 func TestConfigSet_SkillsInclude(t *testing.T) {
 	home := t.TempDir()
-	env := []string{"HOME=" + home, "XDG_CONFIG_HOME=", "DOT_AI_URL=", "DOT_AI_OUTPUT_FORMAT=", "DOT_AI_SKILLS_INCLUDE=", "DOT_AI_SKILLS_EXCLUDE=", "DOT_AI_AUTH_TOKEN="}
+	env := []string{"HOME=" + home, "XDG_CONFIG_HOME=", "DOT_AI_URL=", "DOT_AI_OUTPUT_FORMAT=", "DOT_AI_SKILLS_INCLUDE=", "DOT_AI_SKILLS_EXCLUDE=", "DOT_AI_SKILLS_CUSTOM_ONLY=", "DOT_AI_AUTH_TOKEN="}
 
 	_, _, exitCode := runCLIWithEnv(t, env, "config", "set", "skills.include", "query|recommend")
 	if exitCode != 0 {
@@ -207,7 +207,7 @@ func TestConfigSet_SkillsInclude(t *testing.T) {
 
 func TestConfigSet_SkillsExclude(t *testing.T) {
 	home := t.TempDir()
-	env := []string{"HOME=" + home, "XDG_CONFIG_HOME=", "DOT_AI_URL=", "DOT_AI_OUTPUT_FORMAT=", "DOT_AI_SKILLS_INCLUDE=", "DOT_AI_SKILLS_EXCLUDE=", "DOT_AI_AUTH_TOKEN="}
+	env := []string{"HOME=" + home, "XDG_CONFIG_HOME=", "DOT_AI_URL=", "DOT_AI_OUTPUT_FORMAT=", "DOT_AI_SKILLS_INCLUDE=", "DOT_AI_SKILLS_EXCLUDE=", "DOT_AI_SKILLS_CUSTOM_ONLY=", "DOT_AI_AUTH_TOKEN="}
 
 	_, _, exitCode := runCLIWithEnv(t, env, "config", "set", "skills.exclude", "debug-.*")
 	if exitCode != 0 {
@@ -220,6 +220,37 @@ func TestConfigSet_SkillsExclude(t *testing.T) {
 	}
 	if !strings.Contains(stdout, "debug-.*") {
 		t.Errorf("get skills.exclude = %q, want 'debug-.*'", stdout)
+	}
+}
+
+func TestConfigSet_SkillsCustomOnly(t *testing.T) {
+	home := t.TempDir()
+	env := []string{"HOME=" + home, "XDG_CONFIG_HOME=", "DOT_AI_URL=", "DOT_AI_OUTPUT_FORMAT=", "DOT_AI_SKILLS_INCLUDE=", "DOT_AI_SKILLS_EXCLUDE=", "DOT_AI_SKILLS_CUSTOM_ONLY=", "DOT_AI_AUTH_TOKEN="}
+
+	_, _, exitCode := runCLIWithEnv(t, env, "config", "set", "skills.custom_only", "true")
+	if exitCode != 0 {
+		t.Fatal("set skills.custom_only failed")
+	}
+
+	stdout, _, exitCode := runCLIWithEnv(t, env, "config", "get", "skills.custom_only")
+	if exitCode != 0 {
+		t.Fatal("get skills.custom_only failed")
+	}
+	if !strings.Contains(stdout, "true") {
+		t.Errorf("get skills.custom_only = %q, want 'true'", stdout)
+	}
+}
+
+func TestConfigSet_SkillsCustomOnly_InvalidValue(t *testing.T) {
+	home := t.TempDir()
+	env := []string{"HOME=" + home, "XDG_CONFIG_HOME=", "DOT_AI_URL=", "DOT_AI_OUTPUT_FORMAT=", "DOT_AI_SKILLS_INCLUDE=", "DOT_AI_SKILLS_EXCLUDE=", "DOT_AI_SKILLS_CUSTOM_ONLY=", "DOT_AI_AUTH_TOKEN="}
+
+	_, stderr, exitCode := runCLIWithEnv(t, env, "config", "set", "skills.custom_only", "maybe")
+	if exitCode == 0 {
+		t.Fatal("expected error for invalid skills.custom_only value")
+	}
+	if !strings.Contains(stderr, "must be") {
+		t.Errorf("expected validation error, got: %s", stderr)
 	}
 }
 

--- a/e2e/skills_test.go
+++ b/e2e/skills_test.go
@@ -720,3 +720,116 @@ func TestSkillsGenerate_InstallHook_InHelp(t *testing.T) {
 		t.Error("expected help to mention --install-hook flag")
 	}
 }
+
+func TestSkillsGenerate_CustomOnlyFlag_SkipsToolSkills(t *testing.T) {
+	home := t.TempDir()
+	dir := t.TempDir()
+	env := []string{"HOME=" + home, "DOT_AI_SKILLS_INCLUDE=", "DOT_AI_SKILLS_EXCLUDE=", "DOT_AI_SKILLS_CUSTOM_ONLY="}
+	_, stderr, exitCode := runCLIWithEnv(t, env, "skills", "generate", "--path", dir, "--custom-only")
+	if exitCode != 0 {
+		t.Fatalf("expected exit 0, got %d; stderr: %s", exitCode, stderr)
+	}
+
+	// Prompt skills should exist.
+	for _, prompt := range []string{"troubleshoot-pod", "explain-resource", "security-review", "optimize-resources"} {
+		if _, err := os.Stat(filepath.Join(dir, "dot-ai-"+prompt, "SKILL.md")); err != nil {
+			t.Errorf("expected prompt skill %s to exist", prompt)
+		}
+	}
+
+	// Tool skills should NOT exist.
+	for _, tool := range []string{"query", "recommend", "remediate", "operate", "manageOrgData", "manageKnowledge", "version", "projectSetup", "users"} {
+		if _, err := os.Stat(filepath.Join(dir, "dot-ai-"+tool, "SKILL.md")); !os.IsNotExist(err) {
+			t.Errorf("expected tool skill %s to be absent with --custom-only", tool)
+		}
+	}
+
+	// Routing skill should still exist.
+	if _, err := os.Stat(filepath.Join(dir, "dot-ai", "SKILL.md")); err != nil {
+		t.Error("expected routing skill to exist even with --custom-only")
+	}
+}
+
+func TestSkillsGenerate_CustomOnlyEnvVar(t *testing.T) {
+	home := t.TempDir()
+	dir := t.TempDir()
+	env := []string{"HOME=" + home, "DOT_AI_SKILLS_INCLUDE=", "DOT_AI_SKILLS_EXCLUDE=", "DOT_AI_SKILLS_CUSTOM_ONLY=true"}
+	_, stderr, exitCode := runCLIWithEnv(t, env, "skills", "generate", "--path", dir)
+	if exitCode != 0 {
+		t.Fatalf("expected exit 0, got %d; stderr: %s", exitCode, stderr)
+	}
+
+	// Tool skills should NOT exist.
+	if _, err := os.Stat(filepath.Join(dir, "dot-ai-query", "SKILL.md")); !os.IsNotExist(err) {
+		t.Error("expected tool skills to be absent when DOT_AI_SKILLS_CUSTOM_ONLY=true")
+	}
+
+	// Prompt skills should exist.
+	if _, err := os.Stat(filepath.Join(dir, "dot-ai-troubleshoot-pod", "SKILL.md")); err != nil {
+		t.Error("expected prompt skills to exist")
+	}
+}
+
+func TestSkillsGenerate_CustomOnlyPersistedSetting(t *testing.T) {
+	home := t.TempDir()
+	env := []string{"HOME=" + home}
+
+	_, _, exitCode := runCLIWithEnv(t, env, "config", "set", "skills.custom_only", "true")
+	if exitCode != 0 {
+		t.Fatal("failed to set skills.custom_only")
+	}
+
+	dir := t.TempDir()
+	_, stderr, exitCode := runCLIWithEnv(t, env, "skills", "generate", "--path", dir)
+	if exitCode != 0 {
+		t.Fatalf("expected exit 0, got %d; stderr: %s", exitCode, stderr)
+	}
+
+	if _, err := os.Stat(filepath.Join(dir, "dot-ai-query", "SKILL.md")); !os.IsNotExist(err) {
+		t.Error("expected tool skills to be absent with persisted custom_only setting")
+	}
+	if _, err := os.Stat(filepath.Join(dir, "dot-ai-troubleshoot-pod", "SKILL.md")); err != nil {
+		t.Error("expected prompt skills to exist")
+	}
+}
+
+func TestSkillsGenerate_CustomOnlyWithIncludeExclude(t *testing.T) {
+	home := t.TempDir()
+	dir := t.TempDir()
+	env := []string{"HOME=" + home, "DOT_AI_SKILLS_INCLUDE=", "DOT_AI_SKILLS_EXCLUDE=", "DOT_AI_SKILLS_CUSTOM_ONLY="}
+	_, stderr, exitCode := runCLIWithEnv(t, env, "skills", "generate", "--path", dir,
+		"--custom-only", "--include", "troubleshoot-pod")
+	if exitCode != 0 {
+		t.Fatalf("expected exit 0, got %d; stderr: %s", exitCode, stderr)
+	}
+
+	// Only troubleshoot-pod should exist.
+	if _, err := os.Stat(filepath.Join(dir, "dot-ai-troubleshoot-pod", "SKILL.md")); err != nil {
+		t.Error("expected troubleshoot-pod to exist")
+	}
+
+	// Other prompts should be filtered out.
+	if _, err := os.Stat(filepath.Join(dir, "dot-ai-explain-resource", "SKILL.md")); !os.IsNotExist(err) {
+		t.Error("expected explain-resource to be filtered out by --include")
+	}
+
+	// Tool skills should not exist.
+	if _, err := os.Stat(filepath.Join(dir, "dot-ai-query", "SKILL.md")); !os.IsNotExist(err) {
+		t.Error("expected tool skills to be absent with --custom-only")
+	}
+}
+
+func TestSkillsGenerate_Help_ShowsCustomOnlyFlag(t *testing.T) {
+	cmd := exec.Command(binaryPath, "skills", "generate", "--help")
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("expected exit 0, got error: %v", err)
+	}
+	stdout := string(out)
+	if !strings.Contains(stdout, "--custom-only") {
+		t.Error("expected help to mention --custom-only flag")
+	}
+	if !strings.Contains(stdout, "DOT_AI_SKILLS_CUSTOM_ONLY") {
+		t.Error("expected help to mention DOT_AI_SKILLS_CUSTOM_ONLY env var")
+	}
+}

--- a/internal/auth/settings.go
+++ b/internal/auth/settings.go
@@ -11,10 +11,11 @@ var configDirFunc = defaultConfigDir
 
 // Settings holds durable user preferences stored in settings.json.
 type Settings struct {
-	ServerURL     string `json:"server_url,omitempty"`
-	OutputFormat  string `json:"output_format,omitempty"`
-	SkillsInclude string `json:"skills_include,omitempty"`
-	SkillsExclude string `json:"skills_exclude,omitempty"`
+	ServerURL        string `json:"server_url,omitempty"`
+	OutputFormat     string `json:"output_format,omitempty"`
+	SkillsInclude    string `json:"skills_include,omitempty"`
+	SkillsExclude    string `json:"skills_exclude,omitempty"`
+	SkillsCustomOnly string `json:"skills_custom_only,omitempty"`
 }
 
 func defaultConfigDir() string {

--- a/internal/skills/generator.go
+++ b/internal/skills/generator.go
@@ -139,15 +139,18 @@ func filterByName(names []string, include, exclude string) ([]string, error) {
 // include and exclude are optional regex patterns for filtering skills by name
 // (without the dot-ai- prefix). routingSkill is the embedded routing skill
 // content to write as dot-ai/SKILL.md.
-func Generate(cfg *config.Config, agent, path, include, exclude string, routingSkill []byte) (string, error) {
+func Generate(cfg *config.Config, agent, path, include, exclude string, customOnly bool, routingSkill []byte) (string, error) {
 	outDir, err := resolveDir(agent, path)
 	if err != nil {
 		return "", err
 	}
 
-	tools, err := fetchTools(cfg)
-	if err != nil {
-		return "", err
+	var tools []toolDef
+	if !customOnly {
+		tools, err = fetchTools(cfg)
+		if err != nil {
+			return "", err
+		}
 	}
 
 	prompts, err := fetchPrompts(cfg)


### PR DESCRIPTION
## Description

Add a `--custom-only` flag to `dot-ai skills generate` that excludes MCP tool skills and generates only custom prompt skills. This allows users to include only their custom-authored prompts without the auto-generated MCP tool wrappers.

## Changes Made

- **`internal/auth/settings.go`**: Added `SkillsCustomOnly` field to `Settings` struct
- **`cmd/config.go`**: Added `skills.custom_only` config key with `true`/`false` validation
- **`internal/skills/generator.go`**: Added `customOnly` parameter to `Generate()` - gates the `fetchTools()` call
- **`cmd/skills.go`**: Added `--custom-only` flag with 4-tier precedence resolution (flag > env > config > default)
- **`e2e/skills_test.go`**: 5 new integration tests covering flag, env var, persisted setting, include/exclude interaction, and help output
- **`e2e/config_test.go`**: 2 new tests for config set/get and validation; updated env isolation in existing tests

## Usage

```bash
# Via flag
dot-ai skills generate --agent claude-code --custom-only

# Via environment variable
DOT_AI_SKILLS_CUSTOM_ONLY=true dot-ai skills generate --agent claude-code

# Via persistent config
dot-ai config set skills.custom_only true
dot-ai skills generate --agent claude-code

# Combined with include/exclude filters
dot-ai skills generate --agent claude-code --custom-only --include "troubleshoot.*"
```

## Testing

All integration tests pass, including 5 new tests for the feature and 2 new config tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--custom-only` flag for the `skills generate` command to generate only custom prompt skills while excluding tool skills
  * Introduced `skills.custom_only` persistent configuration option for setting custom-only mode
  * Added `DOT_AI_SKILLS_CUSTOM_ONLY` environment variable support for skill generation configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->